### PR TITLE
PROTOCOL.md: Send default settings only for "configure" request, rename field "response" to "data"

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -14,9 +14,9 @@ The app version is an integer, calculated by `(MAJOR * 1000000) + (MINOR * 1000)
 
 ```
 {
-    "status": "ok",
-    "version": <int>,
-    "response": <any type>
+    "status": "ok",
+    "version": <int>,
+    "response": <any type>
 }
 ```
 
@@ -27,11 +27,11 @@ object that provides any parameters that should accompany the error.
 
 ```
 {
-    "status": "error",
-    "code": <int>,
-    "params": {
-       "<paramN>": <valueN>
-    }
+    "status": "error",
+    "code": <int>,
+    "params": {
+       "<paramN>": <valueN>
+    }
 }
 ```
 
@@ -88,8 +88,8 @@ is alive, determine the version at startup, and provide per-store defaults.
 
 ```
 {
-    "settings": <settings object>,
-    "action": "configure"
+    "settings": <settings object>,
+    "action": "configure"
 }
 ```
 
@@ -98,15 +98,15 @@ is alive, determine the version at startup, and provide per-store defaults.
 ```
 {
 
-    "status": "ok",
-    "version": <int>,
-    "response": {
+    "status": "ok",
+    "version": <int>,
+    "response": {
         "defaultPath": "/path/to/default/store",
         "defaultSettings": "<raw contents of $defaultPath/.browserpass.json>",
-        “storeSettings”: {
-            “storeName”: "<raw contents of storePath/.browserpass.json>"
-        }
-    }
+        “storeSettings”: {
+            “storeName”: "<raw contents of storePath/.browserpass.json>"
+        }
+    }
 }
 ```
 
@@ -119,8 +119,8 @@ is the name of a password store, the key in `"settings.stores"` object.
 
 ```
 {
-    "settings": <settings object>,
-    "action": "list"
+    "settings": <settings object>,
+    "action": "list"
 }
 ```
 
@@ -128,14 +128,14 @@ is the name of a password store, the key in `"settings.stores"` object.
 
 ```
 {
-    "status": "ok",
-    "version": <int>,
-    "response": {
-        "files": {
-            "storeN": ["<storeNPath/file1.gpg>", "<...>"],
-            "storeN+1": ["<storeN+1Path/file1.gpg>", "<...>"]
-        }
-    }
+    "status": "ok",
+    "version": <int>,
+    "response": {
+        "files": {
+            "storeN": ["<storeNPath/file1.gpg>", "<...>"],
+            "storeN+1": ["<storeN+1Path/file1.gpg>", "<...>"]
+        }
+    }
 }
 ```
 
@@ -147,10 +147,10 @@ Get the decrypted contents of a specific file.
 
 ```
 {
-    "settings": <settings object>,
-    "action": "fetch",
-    "store": "<storeName>",
-    "file": "relative/path/to/file.gpg"
+    "settings": <settings object>,
+    "action": "fetch",
+    "store": "<storeName>",
+    "file": "relative/path/to/file.gpg"
 }
 ```
 
@@ -158,10 +158,10 @@ Get the decrypted contents of a specific file.
 
 ```
 {
-    "status": "ok",
-    "version": <int>,
-    "response": {
-        "data": "<decrypted file contents>"
-    }
+    "status": "ok",
+    "version": <int>,
+    "response": {
+        "data": "<decrypted file contents>"
+    }
 }
 ```

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,4 +1,5 @@
 # Browserpass Communication Protocol
+
 This document describes the protocol used for communication between the browser extension,
 and the native host application.
 
@@ -13,9 +14,9 @@ The app version is an integer, calculated by `(MAJOR * 1000000) + (MINOR * 1000)
 
 ```
 {
-    “status”: “ok”,
-    “version”: <int>
-    “response”: <any type>
+    "status": "ok",
+    "version": <int>,
+    "response": <any type>
 }
 ```
 
@@ -26,10 +27,10 @@ object that provides any parameters that should accompany the error.
 
 ```
 {
-    “status”: “error”,
-    “code”: <int>
-    “params”: {
-       “<paramN>”: <valueN>
+    "status": "error",
+    "code": <int>,
+    "params": {
+       "<paramN>": <valueN>
     }
 }
 ```
@@ -56,10 +57,10 @@ and via parameters in individual `*.gpg` files.
 
 Settings are applied using the following priority, highest first:
 
-  1. Configured by the user in specific `*.gpg` files (e.g. autosubmit: true)
-  2. Configured by the user via the extension options
-  3. Configured by the user in each store’s `.browserpass.json` file
-  4. Defaults shipped with the browser extension
+1.  Configured by the user in specific `*.gpg` files (e.g. autosubmit: true)
+2.  Configured by the user via the extension options
+3.  Configured by the user in each store’s `.browserpass.json` file
+4.  Defaults shipped with the browser extension
 
 ### Global Settings
 
@@ -71,10 +72,10 @@ Settings are applied using the following priority, highest first:
 
 ### Store-specific Settings
 
-| Setting      | Description                                          | Default |
-| ------------ | ---------------------------------------------------- | ------- |
-| name         | Store name (same as the store key)                   | <key>   |
-| path         | Path to the password store directory                 | `""`    |
+| Setting | Description                          | Default |
+| ------- | ------------------------------------ | ------- |
+| name    | Store name (same as the store key)   | <key>   |
+| path    | Path to the password store directory | `""`    |
 
 ## Actions
 
@@ -87,8 +88,8 @@ is alive, determine the version at startup, and provide per-store defaults.
 
 ```
 {
-    “settings”: <settings object>,
-    “action”: “configure”
+    "settings": <settings object>,
+    "action": "configure"
 }
 ```
 
@@ -97,13 +98,13 @@ is alive, determine the version at startup, and provide per-store defaults.
 ```
 {
 
-    “status”: “ok”,
-    “version”: <int>
-    “response”: {
+    "status": "ok",
+    "version": <int>,
+    "response": {
         "defaultPath": "/path/to/default/store",
-        "defaultSettings": <raw contents of $defaultPath/.browserpass.json>,
+        "defaultSettings": "<raw contents of $defaultPath/.browserpass.json>",
         “storeSettings”: {
-            “storeName”: <raw contents of storePath/.browserpass.json>
+            “storeName”: "<raw contents of storePath/.browserpass.json>"
         }
     }
 }
@@ -112,14 +113,14 @@ is alive, determine the version at startup, and provide per-store defaults.
 ### List
 
 Get a list of all `*.gpg` files for each of a provided array of directory paths. The `storeN`
-is the name of a password store, the key in `“settings.stores”` object.
+is the name of a password store, the key in `"settings.stores"` object.
 
 #### Request
 
 ```
 {
-    “settings”: <settings object>,
-    “action”: “list”
+    "settings": <settings object>,
+    "action": "list"
 }
 ```
 
@@ -127,12 +128,12 @@ is the name of a password store, the key in `“settings.stores”` object.
 
 ```
 {
-    “status”: “ok”,
-    “version”: <int>,
-    “response”: {
-        “files”: {
-            “storeN”: [<storeNPath/file1.gpg>, <...>],
-            “storeN+1”: [<storeN+1Path/file1.gpg>, <...>]
+    "status": "ok",
+    "version": <int>,
+    "response": {
+        "files": {
+            "storeN": ["<storeNPath/file1.gpg>", "<...>"],
+            "storeN+1": ["<storeN+1Path/file1.gpg>", "<...>"]
         }
     }
 }
@@ -146,10 +147,10 @@ Get the decrypted contents of a specific file.
 
 ```
 {
-    “settings”: <settings object>,
-    “action”: “fetch”,
-    “store”: <storeName>
-    “file”: “relative/path/to/file.gpg”
+    "settings": <settings object>,
+    "action": "fetch",
+    "store": "<storeName>",
+    "file": "relative/path/to/file.gpg"
 }
 ```
 
@@ -157,10 +158,10 @@ Get the decrypted contents of a specific file.
 
 ```
 {
-    “status”: “ok”,
-    “version”: <int>,
-    “response”: {
-        “data”: <decrypted file contents>
+    "status": "ok",
+    "version": <int>,
+    "response": {
+        "data": "<decrypted file contents>"
     }
 }
 ```

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -7,7 +7,7 @@ and the native host application.
 
 ### OK
 
-Consists solely of an `ok` status, an integer app version, and a `response` field. The response
+Consists solely of an `ok` status, an integer app version, and a `data` field which
 may be of any type.
 
 The app version is an integer, calculated by `(MAJOR * 1000000) + (MINOR * 1000) + PATCH`.
@@ -16,7 +16,7 @@ The app version is an integer, calculated by `(MAJOR * 1000000) + (MINOR * 1000)
 {
     "status": "ok",
     "version": <int>,
-    "response": <any type>
+    "data": <any type>
 }
 ```
 
@@ -101,7 +101,7 @@ is alive, determine the version at startup, and provide per-store defaults.
 
     "status": "ok",
     "version": <int>,
-    "response": {
+    "data": {
         "defaultStore": {
             "path": "/path/to/default/store",
             "defaultSettings": "<raw contents of $defaultPath/.browserpass.json>",
@@ -133,7 +133,7 @@ is the name of a password store, the key in `"settings.stores"` object.
 {
     "status": "ok",
     "version": <int>,
-    "response": {
+    "data": {
         "files": {
             "storeN": ["<storeNPath/file1.gpg>", "<...>"],
             "storeN+1": ["<storeN+1Path/file1.gpg>", "<...>"]
@@ -163,7 +163,7 @@ Get the decrypted contents of a specific file.
 {
     "status": "ok",
     "version": <int>,
-    "response": {
+    "data": {
         "data": "<decrypted file contents>"
     }
 }

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -29,6 +29,7 @@ object that provides any parameters that should accompany the error.
 {
     "status": "error",
     "code": <int>,
+    "version": <int>,
     "params": {
        "<paramN>": <valueN>
     }
@@ -64,11 +65,10 @@ Settings are applied using the following priority, highest first:
 
 ### Global Settings
 
-| Setting      | Description                                          | Default |
-| ------------ | ---------------------------------------------------- | ------- |
-| gpgPath      | Optional path to gpg binary                          | `null`  |
-| defaultStore | Store-specific settings for default store            | `{}`    |
-| stores       | List of password stores with store-specific settings | `{}`    |
+| Setting | Description                                          | Default |
+| ------- | ---------------------------------------------------- | ------- |
+| gpgPath | Optional path to gpg binary                          | `null`  |
+| stores  | List of password stores with store-specific settings | `{}`    |
 
 ### Store-specific Settings
 
@@ -89,6 +89,7 @@ is alive, determine the version at startup, and provide per-store defaults.
 ```
 {
     "settings": <settings object>,
+    "defaultStoreSettings": <store-specific settings for default store>,
     "action": "configure"
 }
 ```
@@ -101,8 +102,10 @@ is alive, determine the version at startup, and provide per-store defaults.
     "status": "ok",
     "version": <int>,
     "response": {
-        "defaultPath": "/path/to/default/store",
-        "defaultSettings": "<raw contents of $defaultPath/.browserpass.json>",
+        "defaultStore": {
+            "path": "/path/to/default/store",
+            "defaultSettings": "<raw contents of $defaultPath/.browserpass.json>",
+        },
         “storeSettings”: {
             “storeName”: "<raw contents of storePath/.browserpass.json>"
         }


### PR DESCRIPTION
Sorry, I opened the document in vim and that involved running prettier 🙂

The actual changes are in the last two commits, click on them to review the suggested change in semantics.

I noticed in your PR for extension that the default store will be sent to the host app in the list of stores, so the "defaultSettings" is actually only relevant for the "configure" call and not for all calls. That's why I suggest moving out "defaultSettings" out of generic "settings" object and putting it as a parameter to the "configure" request.