### PR TITLE
Add unit tests for parsing browser requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+
+install:
+  - go get -u github.com/golang/dep/cmd/dep

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ browserpass-freebsd64: *.go **/*.go
 
 .PHONY: test
 test:
-	go test
+	go test ./...

--- a/request/configure.go
+++ b/request/configure.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func configure(request request) {
+func configure(request *request) {
 	responseData := response.MakeConfigureResponse()
 
 	// Check that each and every store in the settings exists and is accessible.

--- a/request/fetch.go
+++ b/request/fetch.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func fetchDecryptedContents(request request) {
+func fetchDecryptedContents(request *request) {
 	responseData := response.MakeFetchResponse()
 
 	if !strings.HasSuffix(request.File, ".gpg") {
@@ -97,7 +97,7 @@ func fetchDecryptedContents(request request) {
 		}
 	}
 
-	responseData.Contents, err = decryptFile(store, request.File, gpgPath)
+	responseData.Contents, err = decryptFile(&store, request.File, gpgPath)
 	if err != nil {
 		log.Errorf(
 			"Unable to decrypt the password file '%v' in the password store '%v' located in '%v': %+v",
@@ -141,7 +141,7 @@ func validateGpgBinary(gpgPath string) error {
 	return exec.Command(gpgPath, "--version").Run()
 }
 
-func decryptFile(store store, file string, gpgPath string) (string, error) {
+func decryptFile(store *store, file string, gpgPath string) (string, error) {
 	passwordFilePath := filepath.Join(store.Path, file)
 	passwordFile, err := os.Open(passwordFilePath)
 	if err != nil {

--- a/request/list.go
+++ b/request/list.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func listFiles(request request) {
+func listFiles(request *request) {
 	responseData := response.MakeListResponse()
 
 	for _, store := range request.Settings.Stores {

--- a/request/process_test.go
+++ b/request/process_test.go
@@ -1,0 +1,43 @@
+package request
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func Test_ParseRequestLength_ConsidersFirstFourBytes(t *testing.T) {
+	// Arrange
+	var expected uint32
+	expected = 201334791 // 0x0c002007
+
+	// First 4 bytes represent the value of `expected` in Little Endian format,
+	// the rest should be completely ignored during the parsing.
+	input := bytes.NewReader([]byte{7, 32, 0, 12, 13, 13, 13})
+
+	// Act
+	actual, err := parseRequestLength(input)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Error parsing request length: %v", err)
+	}
+
+	if expected != actual {
+		t.Fatalf("The actual length '%v' does not match the expected value of '%v'", actual, expected)
+	}
+}
+
+func Test_ParseRequestLength_ConnectionAborted(t *testing.T) {
+	// Arrange
+	expectedErr := io.ErrUnexpectedEOF
+	input := bytes.NewReader([]byte{7})
+
+	// Act
+	_, err := parseRequestLength(input)
+
+	// Assert
+	if expectedErr != err {
+		t.Fatalf("The expected error is '%v', but got '%v'", expectedErr, err)
+	}
+}

--- a/request/process_test.go
+++ b/request/process_test.go
@@ -2,16 +2,17 @@ package request
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
+	"reflect"
 	"testing"
 )
 
 func Test_ParseRequestLength_ConsidersFirstFourBytes(t *testing.T) {
 	// Arrange
-	var expected uint32
-	expected = 201334791 // 0x0c002007
+	expected := uint32(201334791) // 0x0c002007
 
-	// First 4 bytes represent the value of `expected` in Little Endian format,
+	// The first 4 bytes represent the value of `expected` in Little Endian format,
 	// the rest should be completely ignored during the parsing.
 	input := bytes.NewReader([]byte{7, 32, 0, 12, 13, 13, 13})
 
@@ -39,5 +40,76 @@ func Test_ParseRequestLength_ConnectionAborted(t *testing.T) {
 	// Assert
 	if expectedErr != err {
 		t.Fatalf("The expected error is '%v', but got '%v'", expectedErr, err)
+	}
+}
+
+func Test_ParseRequest_CanParse(t *testing.T) {
+	// Arrange
+	expected := &request{
+		Action: "list",
+		Settings: settings{
+			Stores: map[string]store{
+				"default": store{
+					Name: "default",
+					Path: "~/.password-store",
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal("Unable to marshal the expected object to initialize the test")
+	}
+
+	inputLength := uint32(len(jsonBytes))
+	input := bytes.NewReader(jsonBytes)
+
+	// Act
+	actual, err := parseRequest(inputLength, input)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Error parsing request: %v", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("The request was parsed incorrectly.\nExpected: %+v\nActual:   %+v", expected, actual)
+	}
+}
+
+func Test_ParseRequest_WrongLength(t *testing.T) {
+	// Arrange
+	expectedErr := io.ErrUnexpectedEOF
+
+	jsonBytes, err := json.Marshal(&request{Action: "list"})
+	if err != nil {
+		t.Fatal("Unable to marshal the expected object to initialize the test")
+	}
+
+	wrongInputLength := uint32(len(jsonBytes)) - 1
+	input := bytes.NewReader(jsonBytes)
+
+	// Act
+	_, err = parseRequest(wrongInputLength, input)
+
+	// Assert
+	if expectedErr != err {
+		t.Fatalf("The expected error is '%v', but got '%v'", expectedErr, err)
+	}
+}
+
+func Test_ParseRequest_InvalidJson(t *testing.T) {
+	// Arrange
+	jsonBytes := []byte("not_a_json")
+	inputLength := uint32(len(jsonBytes))
+	input := bytes.NewReader(jsonBytes)
+
+	// Act
+	_, err := parseRequest(inputLength, input)
+
+	// Assert
+	if err == nil {
+		t.Fatalf("Expected a parsing error, but didn't get it")
 	}
 }


### PR DESCRIPTION
Made the functions in `request/process.go` return normal go errors instead of sending messages to the extension, so that it's easier to unit test them.