### PR TITLE
Add `expand` request action

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -94,6 +94,38 @@ Settings are applied using the following priority, highest first:
 
 ## Actions
 
+### Expand
+
+Treat every store in request settings as a container of password stores,
+and return the list of direct subfolders that have `*.gpg` files.
+
+#### Request
+
+```
+{
+    "settings": <settings object>,
+    "action": "expand"
+}
+```
+
+#### Response
+
+```
+{
+
+    "status": "ok",
+    "version": <int>,
+    "data": {
+        "stores": {
+            "<containerStoreId>": [{
+                "name": "<storeName>",
+                "path": "<storePath>"
+            }],
+        }
+    }
+}
+```
+
 ### Configure
 
 Returns a response containing the per-store config. Used to check that the host app

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -58,6 +58,9 @@ should be supplied as a `message` parameter.
 | 22   | Unable to detect the location of the gpg binary                         | message, action, error                                      |
 | 23   | Invalid password file extension                                         | message, action, file                                       |
 | 24   | Unable to decrypt the password file                                     | message, action, error, storeId, storePath, storeName, file |
+| 25   | Inaccessible user-configured password stores container                  | message, action, error, storeId, storePath, storeName       |
+| 26   | Unable to list files in a password stores container                     | message, action, error, storeId, storePath, storeName       |
+| 27   | Unable to determine a relative path for a file in a password store      | message, action, error, storeId, storePath, storeName, file |
 
 ## Settings
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -54,6 +54,15 @@ const (
 
 	// CodeUnableToDecryptPasswordFile error decrypting a password file
 	CodeUnableToDecryptPasswordFile Code = 24
+
+	// CodeInaccessiblePasswordStoresContainer error accessing a user-configured password stores container
+	CodeInaccessiblePasswordStoresContainer Code = 25
+
+	// CodeUnableToListFilesInPasswordStoresContainer error listing files in a password stores container
+	CodeUnableToListFilesInPasswordStoresContainer Code = 26
+
+	// CodeUnableToDetermineRelativeFilePathInPasswordStoresContainer error determining a relative path for a file in a password stores container
+	CodeUnableToDetermineRelativeFilePathInPasswordStoresContainer Code = 27
 )
 
 // Field extra field in the error response params

--- a/request/expand.go
+++ b/request/expand.go
@@ -13,65 +13,65 @@ import (
 func expand(request *request) {
 	responseData := response.MakeExpandResponse()
 
-	for _, store := range request.Settings.Stores {
-		normalizedStorePath, err := normalizePasswordStorePath(store.Path)
+	for _, container := range request.Settings.Stores {
+		normalizedStorePath, err := normalizePasswordStorePath(container.Path)
 		if err != nil {
 			log.Errorf(
-				"The password store '%+v' is not accessible at its location: %+v",
-				store, err,
+				"The password stores container '%+v' is not accessible at its location: %+v",
+				container, err,
 			)
 			response.SendErrorAndExit(
-				errors.CodeInaccessiblePasswordStore,
+				errors.CodeInaccessiblePasswordStoresContainer,
 				&map[errors.Field]string{
-					errors.FieldMessage:   "The password store is not accessible",
-					errors.FieldAction:    "list",
+					errors.FieldMessage:   "The password stores container is not accessible",
+					errors.FieldAction:    "expand",
 					errors.FieldError:     err.Error(),
-					errors.FieldStoreID:   store.ID,
-					errors.FieldStoreName: store.Name,
-					errors.FieldStorePath: store.Path,
+					errors.FieldStoreID:   container.ID,
+					errors.FieldStoreName: container.Name,
+					errors.FieldStorePath: container.Path,
 				},
 			)
 		}
 
-		store.Path = normalizedStorePath
+		container.Path = normalizedStorePath
 
-		files, err := zglob.GlobFollowSymlinks(filepath.Join(store.Path, "/**/*.gpg"))
+		files, err := zglob.GlobFollowSymlinks(filepath.Join(container.Path, "/**/*.gpg"))
 		if err != nil {
 			log.Errorf(
-				"Unable to list the files in the password store '%+v' at its location: %+v",
-				store, err,
+				"Unable to list the files in the password stores container '%+v' at its location: %+v",
+				container, err,
 			)
 			response.SendErrorAndExit(
-				errors.CodeUnableToListFilesInPasswordStore,
+				errors.CodeUnableToListFilesInPasswordStoresContainer,
 				&map[errors.Field]string{
-					errors.FieldMessage:   "Unable to list the files in the password store",
-					errors.FieldAction:    "list",
+					errors.FieldMessage:   "Unable to list the files in the password stores container",
+					errors.FieldAction:    "expand",
 					errors.FieldError:     err.Error(),
-					errors.FieldStoreID:   store.ID,
-					errors.FieldStoreName: store.Name,
-					errors.FieldStorePath: store.Path,
+					errors.FieldStoreID:   container.ID,
+					errors.FieldStoreName: container.Name,
+					errors.FieldStorePath: container.Path,
 				},
 			)
 		}
 
 		stores := make(map[string]string)
 		for _, file := range files {
-			relativePath, err := filepath.Rel(store.Path, file)
+			relativePath, err := filepath.Rel(container.Path, file)
 			if err != nil {
 				log.Errorf(
-					"Unable to determine the relative path for a file '%v' in the password store '%+v': %+v",
-					file, store, err,
+					"Unable to determine the relative path for a file '%v' in the password stores container '%+v': %+v",
+					file, container, err,
 				)
 				response.SendErrorAndExit(
-					errors.CodeUnableToDetermineRelativeFilePathInPasswordStore,
+					errors.CodeUnableToDetermineRelativeFilePathInPasswordStoresContainer,
 					&map[errors.Field]string{
-						errors.FieldMessage:   "Unable to determine the relative path for a file in the password store",
-						errors.FieldAction:    "list",
+						errors.FieldMessage:   "Unable to determine the relative path for a file in the password stores container",
+						errors.FieldAction:    "expand",
 						errors.FieldError:     err.Error(),
 						errors.FieldFile:      file,
-						errors.FieldStoreID:   store.ID,
-						errors.FieldStoreName: store.Name,
-						errors.FieldStorePath: store.Path,
+						errors.FieldStoreID:   container.ID,
+						errors.FieldStoreName: container.Name,
+						errors.FieldStorePath: container.Path,
 					},
 				)
 			}
@@ -79,7 +79,7 @@ func expand(request *request) {
 			if len(parts) > 1 {
 				storeName := parts[0]
 				if stores[storeName] == "" {
-					stores[storeName] = filepath.Join(store.Path, storeName)
+					stores[storeName] = filepath.Join(container.Path, storeName)
 				}
 			}
 		}
@@ -90,7 +90,7 @@ func expand(request *request) {
 			storesList[i] = response.MakeExpandedStore(storeName, storePath)
 			i++
 		}
-		responseData.Stores[store.ID] = storesList
+		responseData.Stores[container.ID] = storesList
 	}
 
 	response.SendOk(responseData)

--- a/request/expand.go
+++ b/request/expand.go
@@ -1,0 +1,97 @@
+package request
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/browserpass/browserpass-native/errors"
+	"github.com/browserpass/browserpass-native/response"
+	zglob "github.com/mattn/go-zglob"
+	log "github.com/sirupsen/logrus"
+)
+
+func expand(request *request) {
+	responseData := response.MakeExpandResponse()
+
+	for _, store := range request.Settings.Stores {
+		normalizedStorePath, err := normalizePasswordStorePath(store.Path)
+		if err != nil {
+			log.Errorf(
+				"The password store '%+v' is not accessible at its location: %+v",
+				store, err,
+			)
+			response.SendErrorAndExit(
+				errors.CodeInaccessiblePasswordStore,
+				&map[errors.Field]string{
+					errors.FieldMessage:   "The password store is not accessible",
+					errors.FieldAction:    "list",
+					errors.FieldError:     err.Error(),
+					errors.FieldStoreID:   store.ID,
+					errors.FieldStoreName: store.Name,
+					errors.FieldStorePath: store.Path,
+				},
+			)
+		}
+
+		store.Path = normalizedStorePath
+
+		files, err := zglob.GlobFollowSymlinks(filepath.Join(store.Path, "/**/*.gpg"))
+		if err != nil {
+			log.Errorf(
+				"Unable to list the files in the password store '%+v' at its location: %+v",
+				store, err,
+			)
+			response.SendErrorAndExit(
+				errors.CodeUnableToListFilesInPasswordStore,
+				&map[errors.Field]string{
+					errors.FieldMessage:   "Unable to list the files in the password store",
+					errors.FieldAction:    "list",
+					errors.FieldError:     err.Error(),
+					errors.FieldStoreID:   store.ID,
+					errors.FieldStoreName: store.Name,
+					errors.FieldStorePath: store.Path,
+				},
+			)
+		}
+
+		stores := make(map[string]string)
+		for _, file := range files {
+			relativePath, err := filepath.Rel(store.Path, file)
+			if err != nil {
+				log.Errorf(
+					"Unable to determine the relative path for a file '%v' in the password store '%+v': %+v",
+					file, store, err,
+				)
+				response.SendErrorAndExit(
+					errors.CodeUnableToDetermineRelativeFilePathInPasswordStore,
+					&map[errors.Field]string{
+						errors.FieldMessage:   "Unable to determine the relative path for a file in the password store",
+						errors.FieldAction:    "list",
+						errors.FieldError:     err.Error(),
+						errors.FieldFile:      file,
+						errors.FieldStoreID:   store.ID,
+						errors.FieldStoreName: store.Name,
+						errors.FieldStorePath: store.Path,
+					},
+				)
+			}
+			parts := strings.SplitN(relativePath, "/", 2)
+			if len(parts) > 1 {
+				storeName := parts[0]
+				if stores[storeName] == "" {
+					stores[storeName] = filepath.Join(store.Path, storeName)
+				}
+			}
+		}
+
+		storesList := make([]*response.ExpandedStore, len(stores))
+		i := 0
+		for storeName, storePath := range stores {
+			storesList[i] = response.MakeExpandedStore(storeName, storePath)
+			i++
+		}
+		responseData.Stores[store.ID] = storesList
+	}
+
+	response.SendOk(responseData)
+}

--- a/request/process.go
+++ b/request/process.go
@@ -57,6 +57,8 @@ func Process() {
 	}
 
 	switch request.Action {
+	case "expand":
+		expand(request)
 	case "configure":
 		configure(request)
 	case "list":

--- a/response/response.go
+++ b/response/response.go
@@ -24,6 +24,32 @@ type errorResponse struct {
 	Params  interface{} `json:"params"`
 }
 
+// ExpandedStore a definition of an expanded store
+type ExpandedStore struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+// MakeExpandedStore initializes an expanded store with given information
+func MakeExpandedStore(name string, path string) *ExpandedStore {
+	return &ExpandedStore{
+		Name: name,
+		Path: path,
+	}
+}
+
+// ExpandResponse a response format for the "expand" request
+type ExpandResponse struct {
+	Stores map[string][]*ExpandedStore `json:"stores"`
+}
+
+// MakeExpandResponse initializes an empty expand response
+func MakeExpandResponse() *ExpandResponse {
+	return &ExpandResponse{
+		Stores: make(map[string][]*ExpandedStore),
+	}
+}
+
 // ConfigureResponse a response format for the "configure" request
 type ConfigureResponse struct {
 	DefaultStore struct {


### PR DESCRIPTION
Take the stores in `settings.stores` and return the list of direct subfolders that have at least one `*.gpg` file as a new list of stores.

What do you think about using `settings.stores` as a list of containers? I can of course introduce a new request parameter "containers", but I realized that at the point of requesting "expand" the list of stores is not known anyway, so we can reuse the `settings.stores` to define the list of containers that needs to be expanded.