### PR TITLE
simple msitools installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /browserpass
 /browserpass-*
 dist/
+setup.msi

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BIN_DIR = $(DESTDIR)$(PREFIX)/bin
 LIB_DIR = $(DESTDIR)$(PREFIX)/lib
 SHARE_DIR = $(DESTDIR)$(PREFIX)/share
 
-WINDOWS_BIN = C:\\\\\\\\Program Files (x86)\\\\\\\\Browserpass\\\\\\\\browserpass-windows64.exe
+WINDOWS_BIN = C:\\\\\\\\Program Files\\\\\\\\Browserpass\\\\\\\\browserpass-windows64.exe
 
 GO_GCFLAGS := "all=-trimpath=${PWD}"
 GO_ASMFLAGS := "all=-trimpath=${PWD}"
@@ -361,4 +361,4 @@ policies-brave-user:
 	esac
 
 setup.msi:
-	wixl setup.wxs
+	wixl --arch x64 setup.wxs

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ BIN_DIR = $(DESTDIR)$(PREFIX)/bin
 LIB_DIR = $(DESTDIR)$(PREFIX)/lib
 SHARE_DIR = $(DESTDIR)$(PREFIX)/share
 
+WINDOWS_BIN = C:\\\\\\\\Program Files (x86)\\\\\\\\Browserpass\\\\\\\\browserpass-windows64.exe
+
 GO_GCFLAGS := "all=-trimpath=${PWD}"
 GO_ASMFLAGS := "all=-trimpath=${PWD}"
 GO_LDFLAGS := "-extldflags ${LDFLAGS}"
@@ -86,6 +88,10 @@ dist: clean browserpass-linux64 browserpass-darwin64 browserpass-openbsd64 brows
 configure:
 	$(SED) -i 's|"path": ".*"|"path": "'"$(BIN_DIR)/$(BIN)"'"|' browser-files/chromium-host.json
 	$(SED) -i 's|"path": ".*"|"path": "'"$(BIN_DIR)/$(BIN)"'"|' browser-files/firefox-host.json
+
+configure-windows:
+	$(SED) -i 's|"path": ".*"|"path": "'"$(WINDOWS_BIN)"'"|' browser-files/chromium-host.json
+	$(SED) -i 's|"path": ".*"|"path": "'"$(WINDOWS_BIN)"'"|' browser-files/firefox-host.json
 
 .PHONY: install
 install:
@@ -353,3 +359,6 @@ policies-brave-user:
 	            ;; \
 	*)          echo "The operating system $(OS) is not supported"; exit 1 ;; \
 	esac
+
+setup.msi:
+	wixl setup.wxs

--- a/setup.wxs
+++ b/setup.wxs
@@ -13,12 +13,6 @@
             <File Id='ChromiumHostJSON' Name='chromium-host.json' Source='browser-files/chromium-host.json' />
             <File Id='ChromiumPolicyJSON' Name='chromium-policy.json' Source='browser-files/chromium-policy.json' />
             <File Id='FirefoxHostJSON' Name='firefox-host.json' Source='browser-files/firefox-host.json' />
-            <RegistryKey Id='ChromeNativeMessaging' Root='HKCU' Key='Software\Google\Chrome\NativeMessagingHosts\com.github.browserpass.native' >
-              <RegistryValue Type='string' Name='' Value='C:\Program Files\Browserpass\chromium-host.json'/>
-            </RegistryKey>
-            <RegistryKey Id='FirefoxNativeMessaging' Root='HKCU' Key='Software\Mozilla\NativeMessagingHosts\com.github.browserpass.native' >
-              <RegistryValue Type='string' Name='' Value='C:\Program Files\Browserpass\firefox-host.json'/>
-            </RegistryKey>
             <RegistryKey Id='ChromeNativeMessaging' Root='HKLM' Key='Software\Google\Chrome\NativeMessagingHosts\com.github.browserpass.native' >
               <RegistryValue Type='string' Name='' Value='C:\Program Files\Browserpass\chromium-host.json'/>
             </RegistryKey>

--- a/setup.wxs
+++ b/setup.wxs
@@ -2,11 +2,11 @@
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='Browserpass' Id='ABCDDCBA-86C7-4D14-AEC0-86416A69ABDE' UpgradeCode='ABCDDCBA-7349-453F-94F6-BCB5110BA4FD' Language='1033' Codepage='1252' Version='3.0.6' Manufacturer='Browserpass'>
 
-    <Package Id='*' Keywords='Installer' Manufacturer='Browserpass' InstallerVersion='100' Languages='1033' Compressed='yes' SummaryCodepage='1252' />
+    <Package Id='*' Keywords='Installer' Manufacturer='Browserpass' InstallerVersion='200' Languages='1033' Compressed='yes' SummaryCodepage='1252' />
     <Media Id='1' Cabinet='Sample.cab' EmbedCab='yes' DiskPrompt="CD-ROM #1" />
 
     <Directory Id='TARGETDIR' Name='SourceDir'>
-      <Directory Id='ProgramFilesFolder' Name='PFiles'>
+      <Directory Id='ProgramFiles64Folder' Name='PFiles'>
         <Directory Id='INSTALLDIR' Name='Browserpass'>
           <Component Id='MainExecutable' Guid='ABCDDCBA-83F1-4F22-985B-FDB3C8ABD471'>
             <File Id='BrowserpassEXE' Name='browserpass-windows64.exe' Source='browserpass-windows64.exe' KeyPath='yes'/>
@@ -14,10 +14,16 @@
             <File Id='ChromiumPolicyJSON' Name='chromium-policy.json' Source='browser-files/chromium-policy.json' />
             <File Id='FirefoxHostJSON' Name='firefox-host.json' Source='browser-files/firefox-host.json' />
             <RegistryKey Id='ChromeNativeMessaging' Root='HKCU' Key='Software\Google\Chrome\NativeMessagingHosts\com.github.browserpass.native' >
-              <RegistryValue Type='string' Name='' Value='C:\Program Files (x86)\Browserpass\chromium-host.json'/>
+              <RegistryValue Type='string' Name='' Value='C:\Program Files\Browserpass\chromium-host.json'/>
             </RegistryKey>
             <RegistryKey Id='FirefoxNativeMessaging' Root='HKCU' Key='Software\Mozilla\NativeMessagingHosts\com.github.browserpass.native' >
-              <RegistryValue Type='string' Name='' Value='C:\Program Files (x86)\Browserpass\firefox-host.json'/>
+              <RegistryValue Type='string' Name='' Value='C:\Program Files\Browserpass\firefox-host.json'/>
+            </RegistryKey>
+            <RegistryKey Id='ChromeNativeMessaging' Root='HKLM' Key='Software\Google\Chrome\NativeMessagingHosts\com.github.browserpass.native' >
+              <RegistryValue Type='string' Name='' Value='C:\Program Files\Browserpass\chromium-host.json'/>
+            </RegistryKey>
+            <RegistryKey Id='FirefoxNativeMessaging' Root='HKLM' Key='Software\Mozilla\NativeMessagingHosts\com.github.browserpass.native' >
+              <RegistryValue Type='string' Name='' Value='C:\Program Files\Browserpass\firefox-host.json'/>
             </RegistryKey>
           </Component>
         </Directory>

--- a/setup.wxs
+++ b/setup.wxs
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+  <Product Name='Browserpass' Id='ABCDDCBA-86C7-4D14-AEC0-86416A69ABDE' UpgradeCode='ABCDDCBA-7349-453F-94F6-BCB5110BA4FD' Language='1033' Codepage='1252' Version='3.0.6' Manufacturer='Browserpass'>
+
+    <Package Id='*' Keywords='Installer' Manufacturer='Browserpass' InstallerVersion='100' Languages='1033' Compressed='yes' SummaryCodepage='1252' />
+    <Media Id='1' Cabinet='Sample.cab' EmbedCab='yes' DiskPrompt="CD-ROM #1" />
+
+    <Directory Id='TARGETDIR' Name='SourceDir'>
+      <Directory Id='ProgramFilesFolder' Name='PFiles'>
+        <Directory Id='INSTALLDIR' Name='Browserpass'>
+          <Component Id='MainExecutable' Guid='ABCDDCBA-83F1-4F22-985B-FDB3C8ABD471'>
+            <File Id='BrowserpassEXE' Name='browserpass-windows64.exe' Source='browserpass-windows64.exe' KeyPath='yes'/>
+            <File Id='ChromiumHostJSON' Name='chromium-host.json' Source='browser-files/chromium-host.json' />
+            <File Id='ChromiumPolicyJSON' Name='chromium-policy.json' Source='browser-files/chromium-policy.json' />
+            <File Id='FirefoxHostJSON' Name='firefox-host.json' Source='browser-files/firefox-host.json' />
+            <RegistryKey Id='ChromeNativeMessaging' Root='HKCU' Key='Software\Google\Chrome\NativeMessagingHosts\com.github.browserpass.native' >
+              <RegistryValue Type='string' Name='' Value='C:\Program Files (x86)\Browserpass\chromium-host.json'/>
+            </RegistryKey>
+            <RegistryKey Id='FirefoxNativeMessaging' Root='HKCU' Key='Software\Mozilla\NativeMessagingHosts\com.github.browserpass.native' >
+              <RegistryValue Type='string' Name='' Value='C:\Program Files (x86)\Browserpass\firefox-host.json'/>
+            </RegistryKey>
+          </Component>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Feature Id='Complete' Level='1'>
+      <ComponentRef Id='MainExecutable' />
+    </Feature>
+
+  </Product>
+</Wix>


### PR DESCRIPTION
This is a installer using msitools.
Msitools is limited in functionality: It doesn't support any GUI.
This means that the user is unable to pick the target folder, which is not ideal.
But it also means that the app will always be installed to `C:\Program Files (x86)\Browserpass`.
So in this installer the path is just hard-coded. 

```
make configure-windows
make browserpass-windows64
make setup.msi
```

About WSL:
I don't think you can put files into the WSL filesystem from a windows installer,
so installing browserpass in WSL has to be a separate step. 
But you could make a version of this installer that puts `browserpass-wsl.bat` in place of ` browserpass-windows64.exe`