### PR TITLE
Add support for XDG_DATA_HOME

### DIFF
--- a/request/configure.go
+++ b/request/configure.go
@@ -154,10 +154,14 @@ func getDefaultPasswordStorePath() (string, error) {
 	}
 
 	path = filepath.Join(usr.HomeDir, ".password-store")
+	fileInfo, err := os.Stat(path)
+	if fileInfo != nil {
+		return path, nil
+	}
 
-	xdg_path := os.Getenv("XDG_DATA_HOME")
-	if xdg_path != "" {
-		path = filepath.Join(xdg_path, "password-store")
+	xdgPath := os.Getenv("XDG_DATA_HOME")
+	if xdgPath != "" {
+		path = filepath.Join(xdgPath, "password-store")
 	}
 
 	return path, nil

--- a/request/configure.go
+++ b/request/configure.go
@@ -154,6 +154,12 @@ func getDefaultPasswordStorePath() (string, error) {
 	}
 
 	path = filepath.Join(usr.HomeDir, ".password-store")
+
+	xdg_path := os.Getenv("XDG_DATA_HOME")
+	if xdg_path != "" {
+		path = filepath.Join(xdg_path, "password-store")
+	}
+
 	return path, nil
 }
 

--- a/request/process_test.go
+++ b/request/process_test.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"reflect"
 	"testing"
+	"os"
+	"fmt"
+	"path/filepath"
 )
 
 func Test_ParseRequestLength_ConsidersFirstFourBytes(t *testing.T) {
@@ -112,5 +115,33 @@ func Test_ParseRequest_InvalidJson(t *testing.T) {
 	// Assert
 	if err == nil {
 		t.Fatalf("Expected a parsing error, but didn't get it")
+	}
+}
+
+
+func Test_ParseRequest_GetDefaultPasswordStorePath(t *testing.T) {
+	// Arrange
+	classicPath := fmt.Sprintf("/home/%s/.password-store", os.Getenv("USER"))
+	xdgDataPath := fmt.Sprintf("/home/%s/.local", os.Getenv("USER"))
+	xdgPath := filepath.Join(xdgDataPath, "password-store")
+	os.Unsetenv("XDG_DATA_HOME")
+
+	// Act
+	path, _ := getDefaultPasswordStorePath()
+
+	// Assert
+	if path != classicPath {
+		t.Fatalf("Expected '%s', got '%s'", classicPath, path)
+	}
+
+	// Arrange
+	os.Setenv("XDG_DATA_HOME", xdgDataPath)
+
+	// Act
+	path, _ = getDefaultPasswordStorePath()
+
+	// Assert
+	if path != xdgPath {
+		t.Fatalf("Expected '%s', got '%s'", xdgPath, path)
 	}
 }


### PR DESCRIPTION
Hi,

this is a tentative small PR to add support for the Freedesktop standard XDG_DATA_HOME dir, when the browerpass-native looks for the password-store files.

There is an ongoing discussion on this topic in the [password-store mailing list](https://lists.zx2c4.com/pipermail/password-store/2020-May/004102.html) that hopefully will land to a new release at some point.

I tried reproducing the logic [in this message](https://lists.zx2c4.com/pipermail/password-store/2020-May/004073.html), aimed to be fully retrocompatible with existing installations:

```
	If PASSWORD_STORE_DIR is set use that
	else if ~/.password_store exists use that
	else fallback to the XDG dir behaviour
```
If the logic and intent of this pr are sound I can submit another small patch to align `browserpass-extension`.

I'm open to feedbacks and suggestions as I might have missed some bits.

Thanks for the review!