### PR TITLE
use binary package name for Debian installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following operating systems provide a browserpass package that can be instal
 
 -   Arch Linux: [browserpass](https://www.archlinux.org/packages/community/x86_64/browserpass/)
 -   Gentoo Linux: [browserpass](https://packages.gentoo.org/packages/www-plugins/browserpass)
--   Debian sid: [browserpass](https://packages.debian.org/source/sid/browserpass)
+-   Debian sid: [webext-browserpass](https://packages.debian.org/sid/webext-browserpass)
 -   openSUSE Tumbleweed: [browserpass-native](https://software.opensuse.org/package/browserpass-native)
 -   NixOS: [browserpass](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/security/browserpass/default.nix) - also read [Install on Nix / NixOS](#install-on-nix--nixos)
 -   macOS: [browserpass](https://github.com/Amar1729/homebrew-formulae/blob/master/browserpass.rb) in a user-contributed tap [amar1729/formulae](https://github.com/amar1729/homebrew-formulae)


### PR DESCRIPTION
For the Debian distribution, the README indicates `browserpass` as the name of the package to be used by `apt`. It turns out that `browserpass` is the name of the _source package_. But the _binary package_, the one which can be installed by `apt` and `dpkg` is called, `webext-browserpass`.

This proposed modification reflects this.