### PR TITLE
Allow specifying BIN in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BIN = browserpass
+BIN ?= browserpass
 VERSION = $(shell cat .version)
 
 PREFIX ?= /usr


### PR DESCRIPTION
supplying `BIN=<path to binary> make <target>` does not work for make targets
because the Makefile does not allow BIN to be overridden. This fixes this issue.
