### PR TITLE
Fix OpenBSD pledges

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	openbsd.Pledge("stdio rpath proc exec getpw")
+	openbsd.Pledge("stdio rpath proc exec getpw unix tty")
 
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
 	if isVerbose {

--- a/openbsd/openbsd.go
+++ b/openbsd/openbsd.go
@@ -6,5 +6,5 @@ import "golang.org/x/sys/unix"
 
 // Pledge allowed system calls
 func Pledge(promises string) {
-	unix.Pledge(promises, "")
+	unix.PledgePromises(promises)
 }


### PR DESCRIPTION
- Change call from 'unix.Pledge' to 'unix.PledgePromises' to prevent subprocesses (gpg) from
  being already locked (execpromises="")
- New pledges needed for syslog: unix + tty