### PR TITLE
Use homedir to avoid the dependency to cgo

### DIFF
--- a/request/configure.go
+++ b/request/configure.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/browserpass/browserpass-native/errors"
@@ -148,12 +147,12 @@ func getDefaultPasswordStorePath() (string, error) {
 		return path, nil
 	}
 
-	usr, err := user.Current()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	path = filepath.Join(usr.HomeDir, ".password-store")
+	path = filepath.Join(home, ".password-store")
 	return path, nil
 }
 


### PR DESCRIPTION
Hi,

I was about to switch from `gopass` back to simply `pass` and wanted to use `browserpass` as the browser extension to interact with my passwords.

My laptop is running an Ubuntu 20.04 distribution and is connected to my company’s active directory. I would first like to mention that I don’t exactly get all the ins and outs of the problem I am encountering, but I’ll try to explain as much as I can.

To authenticate with our active directory, we make use of `sssd` which is a package that provides NSS and PAM interfaces. System calls that interact with authentications and users will then call those implementations instead of the native ones at runtime. This normally works pretty well and is transparent.

Let’s say for example that I have this simple Go program, that makes use of `os/user.Current()` (which is a cgo binding calling the underlying `getuid()` system call). 

```
package main

import (
	"fmt"
	"os/user"
)

func main() {
	usr, err := user.Current()
	if err != nil {
		panic(err)
	}

	fmt.Println(usr.HomeDir)
}
```

When I normally compile this problem (so dynamically linked) and run it, it works as expected and the NSS interface does its job.

However, in the context of `browserpass-native`, I am not sure exactly how the binary is called by the browser, but the story is different. I have added some debug at this line in the program: https://github.com/browserpass/browserpass-native/blob/915aff09a71c077c58ee1ea7da9c8383534eb9f6/request/configure.go#L151 and here is the result of `os/user.Current()`.

```
user: unknown userid 1000
```

So here I submit this PR to propose to use the Go implementation of Mitchell Hashimoto to fetch the home directory without calling to cgo. I know this adds an external dependency (which we often want to avoid), but this fixes such strange problems.

Thanks a lot in advance