### PR TITLE
Add brew standard installation path for gpg common paths

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -17,6 +17,7 @@ func DetectGpgBinary() (string, error) {
 		"gpg2", "gpg",
 		"/bin/gpg2", "/usr/bin/gpg2", "/usr/local/bin/gpg2",
 		"/bin/gpg", "/usr/bin/gpg", "/usr/local/bin/gpg",
+		"/opt/homebrew/bin/gpg",
 	}
 
 	for _, binary := range gpgBinaryPriorityList {


### PR DESCRIPTION
On macOS, we generally use `brew` to install `gpg`. This PR aims to add the brew installed `gpg` binary path to the common paths to look up for.

In my case, for some unknown reason, `gpg` was not resolved while it is actually part of the `$PATH` variable.