### PR TITLE
Clarify macOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ The following operating systems provide a browserpass package that can be instal
 -   openSUSE Tumbleweed: [browserpass-native](https://software.opensuse.org/package/browserpass-native)
 -   NixOS: [browserpass](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/security/browserpass/default.nix) - also read [Install on Nix / NixOS](#install-on-nix--nixos)
 -   macOS: [browserpass](https://github.com/Amar1729/homebrew-formulae/blob/master/Formula/browserpass.rb) in a user-contributed tap [amar1729/formulae](https://github.com/amar1729/homebrew-formulae)
+    ```sh
+    brew tap amar1729/formulae
+    brew install browserpass # this will print further installation instructions, e.g. for Firefox:
+    PREFIX='/opt/homebrew/opt/browserpass' make hosts-firefox-user -f '/opt/homebrew/opt/browserpass/lib/browserpass/Makefile'
+    ```
 
 Once the package is installed, **refer to the section [Configure browsers](#configure-browsers)**.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following operating systems provide a browserpass package that can be instal
 -   Debian sid: [webext-browserpass](https://packages.debian.org/sid/webext-browserpass) (note: users report ([#126](https://github.com/browserpass/browserpass-native/issues/126)) that it's not suitable for any browser besides Chromium and Firefox, use manual installation if you plan to use other browsers).
 -   openSUSE Tumbleweed: [browserpass-native](https://software.opensuse.org/package/browserpass-native)
 -   NixOS: [browserpass](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/security/browserpass/default.nix) - also read [Install on Nix / NixOS](#install-on-nix--nixos)
--   macOS: [browserpass](https://github.com/Amar1729/homebrew-formulae/blob/master/Formula/browserpass.rb) in a user-contributed tap [amar1729/formulae](https://github.com/amar1729/homebrew-formulae)
+-   macOS (Homebrew): [browserpass](https://github.com/Amar1729/homebrew-formulae/blob/master/Formula/browserpass.rb) in a user-contributed tap [amar1729/formulae](https://github.com/amar1729/homebrew-formulae)
     ```sh
     brew tap amar1729/formulae
     brew install browserpass # this will print further installation instructions, e.g. for Firefox:


### PR DESCRIPTION
To make installation on macOS a bit easier, I added the commands that are required to install browserpass.

In particular a 'tap' needs to be configured (which some users may not be familiar with).

Also upon installation further instructions are printed, which are only shown once and are easy to miss.