### PR TITLE
Improve README for Windows (Not WSL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ $ DESTDIR=~/.nix-profile make -f ~/.nix-profile/lib/browserpass/Makefile <desire
 
 Download [the latest Github release](https://github.com/browserpass/browserpass-native/releases/latest) for `windows64`.
 
-Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will also [configure browsers](#configure-browsers).
+Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will also [configure browsers](#configure-browsers).  
+Browserpass will look for the password store in `C:\Users\<user>\.password-store`. The log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
 
 #### Install on Windows through WSL
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ $ DESTDIR=~/.nix-profile make -f ~/.nix-profile/lib/browserpass/Makefile <desire
 Download [the latest Github release](https://github.com/browserpass/browserpass-native/releases/latest) for `windows64`.
 
 Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will also [configure browsers](#configure-browsers).  
-Browserpass will look for the password store in `C:\Users\<user>\.password-store`. The log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
+Browserpass will look for the password store in `C:\Users\<user>\.password-store` by default. The log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
 
 #### Install on Windows through WSL
 


### PR DESCRIPTION
This update just gives some very minimal info to help the next fellow, because I struggled setting it up. For me installing then running the precompiled executable looked like the program just hangs and does nothing.  
I don't know if the errors are supposed to be printed, I could only find them later in the log file or by running the thing in verbose. 

Also I don't think I could find the command line usage anywhere? I could add it to the README too if you ask me.  