### PR TITLE
 Improve README for Windows (Not WSL) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ $ DESTDIR=~/.nix-profile make -f ~/.nix-profile/lib/browserpass/Makefile <desire
 
 Download [the latest Github release](https://github.com/browserpass/browserpass-native/releases/latest) for `windows64`.
 
-Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will also [configure browsers](#configure-browsers).
+Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will also [configure browsers](#configure-browsers).  
+Browserpass will look for the password store in `C:\Users\<user>\.password-store`. The log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
 
 #### Install on Windows through WSL
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ $ DESTDIR=~/.nix-profile make -f ~/.nix-profile/lib/browserpass/Makefile <desire
 Download [the latest Github release](https://github.com/browserpass/browserpass-native/releases/latest) for `windows64`.
 
 Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will also [configure browsers](#configure-browsers).  
-Browserpass will look for the password store in `C:\Users\<user>\.password-store`. The log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
+Browserpass will look for the password store in `C:\Users\<user>\.password-store` by default. The log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
 
 #### Install on Windows through WSL
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ $ DESTDIR=~/.nix-profile make -f ~/.nix-profile/lib/browserpass/Makefile <desire
 
 Download [the latest Github release](https://github.com/browserpass/browserpass-native/releases/latest) for `windows64`.
 
-Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will also [configure browsers](#configure-browsers).  
-Browserpass will look for the password store in `C:\Users\<user>\.password-store` by default. The log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
+Run the installer, it will install all the necessary files in `C:\Program Files\Browserpass` and it will write in the Windows registry to [configure browsers](#configure-browsers).  
+Browserpass will look for the password store in `C:\Users\<user>\.password-store` by default. For troubleshooting, the log file can be found in `C:\Users\<user>\AppData\Local\browserpass`. 
 
 #### Install on Windows through WSL
 
@@ -149,6 +149,8 @@ bash -c "/usr/bin/browserpass-linux64 2>/dev/null"
 Remember to check [Hints for configuring gpg](#error-unable-to-fetch-and-parse-login-fields) on how to configure pinentry to unlock your PGP key.
 
 ### Configure browsers
+
+#### Unix-like Systems
 
 The following operating systems provide packages for certain browsers that can be installed using a package manager:
 
@@ -214,6 +216,14 @@ In addition, Chromium-based browsers support the following `make` goals:
 | `sudo make policies-vivaldi`  | Automatically install browser extension from Web Store for Vivaldi browser, system-wide                      |
 | `sudo make policies-yandex`   | Automatically install browser extension from Web Store for Yandex browser, system-wide                       |
 | `sudo make policies-arc`      | Automatically install browser extension from Web Store for Arc browser, system-wide                          |
+
+#### Windows
+
+The browser will fetch the configuration file from the registry, checking for the full path to the manifest file (such as `firefox-host.json`) in the registry in either:
+- (Firefox) `Software\Mozilla\NativeMessagingHosts\com.github.browserpass.native\(default)`
+- (Chromium-based) `Software\Google\Chrome\NativeMessagingHosts\com.github.browserpass.native\(default)`
+
+This should be automatically done for you if you ran the released installer.  
 
 ## Building the app
 


### PR DESCRIPTION
This update just gives some very minimal info to help the next fellow, because I struggled setting it up. For me installing then running the precompiled executable looked like the program just hangs and does nothing.  
I don't know if the errors are supposed to be printed, I could only find them later in the log file or by running the thing in verbose. 

Also I don't think I could find the command line usage anywhere? I could add it to the README too if you ask me.  