### PR TITLE
Use the v3 module path for all local imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
-	github.com/browserpass/browserpass-native v0.0.0-20250425203345-8419b15841c9
 	github.com/mattn/go-zglob v0.0.6
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/browserpass/browserpass-native v0.0.0-20250425203345-8419b15841c9 h1:FEzf2eEEOEhsS1Fa1XUyFBVIDtMY4AWzu9XVDXYeUw0=
-github.com/browserpass/browserpass-native v0.0.0-20250425203345-8419b15841c9/go.mod h1:a8E0vP2qoBpjgFqwdCOMPAqDtZ088hVRJTpWsggHC38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/browserpass/browserpass-native/openbsd"
-	"github.com/browserpass/browserpass-native/persistentlog"
-	"github.com/browserpass/browserpass-native/request"
-	"github.com/browserpass/browserpass-native/version"
+	"github.com/browserpass/browserpass-native/v3/openbsd"
+	"github.com/browserpass/browserpass-native/v3/persistentlog"
+	"github.com/browserpass/browserpass-native/v3/request"
+	"github.com/browserpass/browserpass-native/v3/version"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/request/configure.go
+++ b/request/configure.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/helpers"
-	"github.com/browserpass/browserpass-native/response"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/helpers"
+	"github.com/browserpass/browserpass-native/v3/response"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/request/delete.go
+++ b/request/delete.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/helpers"
-	"github.com/browserpass/browserpass-native/response"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/helpers"
+	"github.com/browserpass/browserpass-native/v3/response"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/request/fetch.go
+++ b/request/fetch.go
@@ -4,9 +4,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/helpers"
-	"github.com/browserpass/browserpass-native/response"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/helpers"
+	"github.com/browserpass/browserpass-native/v3/response"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/request/list.go
+++ b/request/list.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/response"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/response"
 	"github.com/mattn/go-zglob"
 	log "github.com/sirupsen/logrus"
 )

--- a/request/process.go
+++ b/request/process.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/response"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/response"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/request/save.go
+++ b/request/save.go
@@ -4,9 +4,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/helpers"
-	"github.com/browserpass/browserpass-native/response"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/helpers"
+	"github.com/browserpass/browserpass-native/v3/response"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/request/tree.go
+++ b/request/tree.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/response"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/response"
 	"github.com/mattn/go-zglob/fastwalk"
 	log "github.com/sirupsen/logrus"
 )

--- a/response/response.go
+++ b/response/response.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/browserpass/browserpass-native/errors"
-	"github.com/browserpass/browserpass-native/version"
+	"github.com/browserpass/browserpass-native/v3/errors"
+	"github.com/browserpass/browserpass-native/v3/version"
 	log "github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Commit 49edb29 ("update module name and deps") appended /v3 to the module path. Since a require stanza was also added to have a dependency to this module itself at commit 8419b15 (" Improve README for Windows (Not WSL) (#163)") things kept working.

However, this might be confusing since local changes to the code will seemingly not have an effect. The pinned self-dependency also prints the wrong version for v3.1.2:

$ browserpass --version
Browserpass host app version: 3.1.0